### PR TITLE
security: pin axios to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "@actions/github": "^2.1.1",
-    "axios": "^0.19.2"
+    "axios": "0.19.2"
   }
 }


### PR DESCRIPTION
## Summary
- Pins axios dependency to an exact version (removes `^` range specifier)
- Axios versions **1.14.1** and **0.30.4** have been identified as compromised
- This prevents npm/yarn from resolving to a compromised version on fresh installs

## Action needed
- Review and merge ASAP
- After merging, run `npm install` / `yarn install` to regenerate lockfile
- Verify your lockfile does NOT contain axios 1.14.1 or 0.30.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin axios to exact version 0.19.2
> Changes the axios dependency in [package.json](https://github.com/parkhub/save-repo-for-jira-action/pull/22/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `^0.19.2` to `0.19.2`, ensuring the exact version is installed rather than any compatible `0.19.x` release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0ed7de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->